### PR TITLE
Compile cleanly with `-Wall` on gcc 4.8.1.

### DIFF
--- a/winbolo/src/bolo/backend.c
+++ b/winbolo/src/bolo/backend.c
@@ -35,6 +35,9 @@ static struct timeval start_time;
 #endif
 
 bool threadsGetContext();
+void serverCoreCenterTank();
+void clientSoundDist(sndEffects value, BYTE mx, BYTE my);
+void serverCoreSoundDist(sndEffects value, BYTE mx, BYTE my);
 
 /* Current building item selected */
 buildSelect BsCurrent = BsTrees;

--- a/winbolo/src/bolo/bases.c
+++ b/winbolo/src/bolo/bases.c
@@ -328,15 +328,14 @@ void basesUpdate(bases *value, tank *tnk) {
   BYTE count;              /* Looping Variable */
   int secondCounter;       /* another looping variable */
   bool isServer;           /* Are we the server */
-  double numPlayers;         /* Number of players */
 
   count = 0;
   secondCounter = 0;
   
   isServer = threadsGetContext();
-  numPlayers = playersGetNumPlayers(screenGetPlayers());
   /* Old Algorithm */
-/*  maxTime = (800.0 / numPlayers); // maxTime was defined as a double
+  /* numPlayers = playersGetNumPlayers(screenGetPlayers());
+  maxTime = (800.0 / numPlayers); // maxTime was defined as a double
   while (count < (*value)->numBases) {
     (*value)->item[count].baseTime++;
     if ((*value)->item[count].baseTime >= maxTime) {
@@ -1602,10 +1601,8 @@ BYTE basesGetNumberOwnedByPlayer(bases *value, BYTE playerNum) {
 int basesHalfTickCalulator(int typeSelector) {
 	static double lastShell;
 	static double lastMine;
-	static double lastArmour;
 	double tempShell = 0;
 	double tempMine = 0;
-	double tempArmour = 0;
 
 	switch(typeSelector)
 	{

--- a/winbolo/src/bolo/bolo_map.c
+++ b/winbolo/src/bolo/bolo_map.c
@@ -1735,7 +1735,7 @@ int mapMakeNetRun(map *value, BYTE *buff, BYTE yPos) {
     count++;
   }
   /* Compress it */
-  return lzwencoding(array, buff, 6*(MAP_MINE_EDGE_RIGHT-(MAP_MINE_EDGE_LEFT+1)));
+  return lzwencoding((char*)array, (char*)buff, 6*(MAP_MINE_EDGE_RIGHT-(MAP_MINE_EDGE_LEFT+1)));
 }
 
 /*********************************************************
@@ -1762,7 +1762,7 @@ void mapSetNetRun(map *value, BYTE *buff, BYTE yPos, int dataLen) {
   count = 0;
   arrayPtr = array;
   /* Compress it */
-  lzwdecoding(buff, array, dataLen);
+  lzwdecoding((char*)buff, (char*)array, dataLen);
   /* Store it */
   while (count < 6) {
     for (xPos=MAP_MINE_EDGE_LEFT+1;xPos < MAP_MINE_EDGE_RIGHT;xPos++) {
@@ -1877,7 +1877,7 @@ int mapSaveCompressedMap(map *value, pillboxes *pb, bases *bs, starts *ss, BYTE 
 
   /* Map */
   ptr2 = (BYTE *) (*value)->mapItem;
-  returnValue += lzwencoding((char *) (ptr2), ptr, sizeof(**value));
+  returnValue += lzwencoding((char *) (ptr2), (char*)ptr, sizeof(**value));
   return returnValue;
 }
 
@@ -1925,7 +1925,7 @@ bool mapLoadCompressedMap(map *value, pillboxes *pb, bases *bs, starts *ss, BYTE
 
   /* Map */
   ptr2 = (BYTE *) (*value)->mapItem;
-  mapSize = lzwdecoding(ptr, ptr2, inputLen);
+  mapSize = lzwdecoding((char*)ptr, (char*)ptr2, inputLen);
   if (mapSize != sizeof(**value) - 2 * sizeof(mapNet)) {
     returnValue = FALSE;
   }

--- a/winbolo/src/bolo/lgm.c
+++ b/winbolo/src/bolo/lgm.c
@@ -134,7 +134,6 @@ void lgmUpdate(lgm *lgman, map *mp, pillboxes *pb, bases *bs, tank *tnk) {
 	BYTE my= 0;
 	WORLD wx;
 	WORLD wy;
-	WORLD t;
 
 	/* Single player or server instance */
 	if (netGetType() == netSingle || threadsGetContext() == TRUE) {
@@ -732,7 +731,7 @@ void lgmMoveAway(lgm *lgman, map *mp, pillboxes *pb, bases *bs, tank *tnk) {
     noGo = TRUE;
     newbmy = bmy;
   }
-  if (((mapGetManSpeed(mp, pb, bs, newbmx, newbmy,(*lgman)->playerNum) )) > 0 && xAdd != 0 || onBoat == TRUE) {
+  if ((((mapGetManSpeed(mp, pb, bs, newbmx, newbmy,(*lgman)->playerNum) )) > 0 && xAdd != 0) || onBoat == TRUE) {
     (*lgman)->x = (WORLD) ((*lgman)->x + xAdd);
   } else if (newbmx == (*lgman)->blessX && bmy == (*lgman)->blessY && lgmCheckBlessedSquare(newbmx, newbmy, (*lgman)->action, mp, pb, bs, tnk) == TRUE) {
     (*lgman)->x = (WORLD) ((*lgman)->x + xAdd);

--- a/winbolo/src/bolo/log.c
+++ b/winbolo/src/bolo/log.c
@@ -292,7 +292,7 @@ void logAddEvent(logitem itemNum, BYTE opt1, BYTE opt2, BYTE opt3, BYTE opt4, un
       logMemSize++;
       *(logMem+logMemSize) = (BYTE) short1 ^ logKey;
       logMemSize++;
-      logAddToMemory((logMem+logMemSize), words, (BYTE) (words[0]+1));
+      logAddToMemory((logMem+logMemSize), (BYTE *) words, (BYTE) (words[0]+1));
 //      memcpy((logMem+logMemSize), words, words[0]+1);
       logMemSize += (BYTE) (words[0]+1);
       break;
@@ -323,7 +323,7 @@ void logAddEvent(logitem itemNum, BYTE opt1, BYTE opt2, BYTE opt3, BYTE opt4, un
       logMemSize++;
       *(logMem+logMemSize) = opt1 ^ logKey;
       logMemSize++;
-      logAddToMemory((logMem+logMemSize), words, (BYTE) (words[0]+1));
+      logAddToMemory((logMem+logMemSize), (BYTE *) words, (BYTE) (words[0]+1));
 //      memcpy((logMem+logMemSize), words, words[0]+1);
       logMemSize += (BYTE) (words[0]+1);
       break;
@@ -441,7 +441,7 @@ void logAddEvent(logitem itemNum, BYTE opt1, BYTE opt2, BYTE opt3, BYTE opt4, un
       logMemSize++;
       *(logMem+logMemSize) = opt2 ^ logKey;
       logMemSize++;
-      logAddToMemory((logMem+logMemSize), words, (BYTE) (words[0]+1));
+      logAddToMemory((logMem+logMemSize), (BYTE *) words, (BYTE) (words[0]+1));
       logMemSize += (BYTE) (words[0]+1);
       break;
     case log_MessageAll:
@@ -450,14 +450,14 @@ void logAddEvent(logitem itemNum, BYTE opt1, BYTE opt2, BYTE opt3, BYTE opt4, un
       *(logMem+logMemSize) = opt1 ^ logKey;
       logMemSize++;
       //FIXTHIS
-      logAddToMemory((logMem+logMemSize), words, (BYTE) (words[0]+1));
+      logAddToMemory((logMem+logMemSize), (BYTE *) words, (BYTE) (words[0]+1));
       //memcpy((logMem+logMemSize), words, words[0]+1);
       logMemSize += (BYTE) (words[0]+1);
       break;
     case log_MessageServer:
       *(logMem+logMemSize) = log_MessageServer ^ logKey;
       logMemSize++;
-      logAddToMemory((logMem+logMemSize), words, (BYTE) (words[0]+1));
+      logAddToMemory((logMem+logMemSize), (BYTE *) words, (BYTE) (words[0]+1));
       //memcpy((logMem+logMemSize), words, words[0]+1);
       logMemSize += (BYTE) (words[0]+1);
       break;
@@ -719,8 +719,8 @@ bool logStart(char *fileName, map *mp, bases *bs, pillboxes *pb, starts *ss, pla
   if (ret != Z_OK) {
     returnValue = FALSE;
   } else {
-    strcpy(data, LOG_HEADER);
-    ret = zipWriteInFileInZip(logFile, data, (unsigned int) strlen(data));
+    strcpy((char *) data, LOG_HEADER);
+    ret = zipWriteInFileInZip(logFile, data, (unsigned int) strlen((char *) data));
     if (ret != Z_OK) {
       returnValue = FALSE;
     }
@@ -738,8 +738,8 @@ bool logStart(char *fileName, map *mp, bases *bs, pillboxes *pb, starts *ss, pla
 
   /* Write Map Name */
   if (returnValue == TRUE) {
-    serverCoreGetMapName(data+1);
-    data[0] = (BYTE) strlen(data+1);
+    serverCoreGetMapName((char *) data+1);
+    data[0] = (BYTE) strlen((char *) data+1);
     ret = zipWriteInFileInZip(logFile, data, data[0]+1);
     if (ret != Z_OK) {
       returnValue = FALSE;

--- a/winbolo/src/bolo/mathWinbolo.c
+++ b/winbolo/src/bolo/mathWinbolo.c
@@ -264,18 +264,18 @@ int mathAngleTravelUsingComponents(float speedX, float speedY)
  */
 void mathUpdateVectorBody(struct vectorBody *vB, SPEEDTYPE speed, WORLD currentX, WORLD currentY, WORLD prevX, WORLD prevY, TURNTYPE angle)
 {
-	int i;
+	//int i;
 	float actualTankSpeed;
 
 	/* This is just here for debugging purposes.  It allows me to
-	 * catch the tanks speed, angle, and component speeds. */
+	 * catch the tanks speed, angle, and component speeds. 
 	if (speed > 10.0)
 	{
 		if ((currentX - prevX < 0) || ((*vB).speedX < 0))
 		{
 			i = 0;
 		}
-	}
+	}*/
 
 	actualTankSpeed = mathGetDistanceBetweenTwoPoints(currentX, currentY, prevX, prevY);
 

--- a/winbolo/src/bolo/netmt.c
+++ b/winbolo/src/bolo/netmt.c
@@ -40,6 +40,7 @@
 #include "minesexp.h"
 #include "netmt.h"
 #include "network.h"
+#include "netplayers.h"
 #include "players.h"
 #include "rubble.h"
 #include "screen.h"
@@ -52,6 +53,9 @@
 
 /* Protos */
 void netErrorOccured();
+void tankResetHitCount(tank *value);
+void tankAddHit(tank *value, int amount);
+netPlayers *serverNetGetNetPlayers();
 
 /*********************************************************
 *NAME:          netMNTCreate
@@ -152,12 +156,12 @@ void netMNTAdd(netMntContext *nmtc, BYTE event, BYTE itemNum, BYTE owner, BYTE o
 int netMNTMake(netMntContext *nmtc, BYTE *buff) {
   int returnValue; /* Value to return */
   BYTE *pnt;       /* Pointer to the buffer */
-  bool isServer;   /* Are we the server */
+  //bool isServer;   /* Are we the server */
   int count;       /* Looping variable */
   netMnt q;
 
   
-  isServer = threadsGetContext();
+  //isServer = threadsGetContext();
   returnValue = 0;
   pnt = buff;
   count = 1;
@@ -450,9 +454,9 @@ bool netMNTExtract(netMntContext *nmtc, map *mp, pillboxes *pb, bases *bs, tank 
   BYTE opt2;
   bool testCalc;    /* Does the screen need a recalc? */
   bool needCalc;    /* Does the screen need a recalc? */
-  BYTE id;          /* Item ID */
+  //BYTE id;          /* Item ID */
   BYTE owner;       /* Who owns this */
-  BYTE eventNibble; 
+  //BYTE eventNibble; 
   bool isServer;    /* Are we server */
   bool errOccurred; /* Has an packet avert error occurred? */
 
@@ -464,11 +468,11 @@ bool netMNTExtract(netMntContext *nmtc, map *mp, pillboxes *pb, bases *bs, tank 
 
   while (count < dataLen) {
     utilGetNibbles(buff[count],&event, &itemNum);
-    eventNibble = buff[count];
+    //eventNibble = buff[count];
     count++;
     owner = buff[count];
     count++;
-    id = buff[count];
+    //id = buff[count];
     count++;
     opt1 = buff[count];
     count++;

--- a/winbolo/src/bolo/netpnb.c
+++ b/winbolo/src/bolo/netpnb.c
@@ -41,6 +41,8 @@
 
 #include "../server/servercore.h"
 
+void tankAddHit(tank *value, int amount);
+
 
 /*********************************************************
 *NAME:          netPNBCreate
@@ -144,11 +146,11 @@ void netPNBAdd(netPnbContext *pnbc, BYTE event, BYTE itemNum, BYTE owner, BYTE o
 int netPNBMake(netPnbContext *pnbc, BYTE *buff) {
   int returnValue; /* Value to return */
   BYTE *pnt;       /* Pointer to the buffer */
-  bool isServer;   /* Are we the server */
+  //bool isServer;   /* Are we the server */
   int count;       /* Looping variable */
   netPnb q;
 
-  isServer = threadsGetContext();
+  //isServer = threadsGetContext();
   returnValue = 0;
   pnt = buff;
   count = 1;
@@ -547,14 +549,14 @@ bool netPNBExtract(netPnbContext *pnbc, map *mp, bases *bs, pillboxes *pb, BYTE 
   BYTE event;       /* Event Type */
   BYTE itemNum;     /* Item Number */
   BYTE owner;       /* Owner       */
-  BYTE id;          /* item Id     */
+  //BYTE id;          /* item Id     */
   BYTE opt1;        /* Optional Data */
   BYTE opt2;
   BYTE opt3;
   bool needCalc;    /* Does the screen need a recalc? */
   bool testCalc;    /* Does the screen need a recalc? */
   bool isServer;    /* Are we a server */
-  BYTE eventNibble; 
+  //BYTE eventNibble; 
   bool errOccurred; /* Has an packet avert error occurred? */
 
   errOccurred = FALSE;
@@ -565,11 +567,11 @@ bool netPNBExtract(netPnbContext *pnbc, map *mp, bases *bs, pillboxes *pb, BYTE 
 
   while (count < dataLen) {
     utilGetNibbles(buff[count],&event, &itemNum);
-    eventNibble = buff[count];
+    //eventNibble = buff[count];
     count++;
     owner = buff[count];
     count++;
-    id = buff[count];
+    //id = buff[count];
     count++;
     opt1 = buff[count];
     count++;

--- a/winbolo/src/bolo/pillbox.c
+++ b/winbolo/src/bolo/pillbox.c
@@ -1092,7 +1092,7 @@ bool pillsMoveView(pillboxes *value, BYTE *mx, BYTE *my, int xMove, int yMove) {
   myPlayerNum = playersGetSelf(screenGetPlayers());
   while (count < (*value)->numPills) {
     if (count != oldPill && (playersIsAllie(screenGetPlayers(), myPlayerNum, (*value)->item[count].owner) == TRUE) && ((*value)->item[count].armour) > 0 && ((*value)->item[count].inTank) == FALSE) {
-      if ((yMove == 0 && (xMove < 0 && (*value)->item[count].x < *mx) || (xMove > 0 && (*value)->item[count].x > *mx)) || (xMove == 0 && (yMove < 0 && (*value)->item[count].y < *my) || (yMove > 0 && (*value)->item[count].y > *my))) {
+      if (((yMove == 0 && xMove < 0 && (*value)->item[count].x < *mx) || (xMove > 0 && (*value)->item[count].x > *mx)) || ((xMove == 0 && yMove < 0 && (*value)->item[count].y < *my) || (yMove > 0 && (*value)->item[count].y > *my))) {
         if (utilIsItemInRange(*mx, *my, (*value)->item[count].x, (*value)->item[count].y, (WORLD) nearest, &dist) == TRUE) {
           nearest = dist;
           found = count;
@@ -1469,10 +1469,8 @@ void pillsMigrate(pillboxes *value, BYTE oldOwner, BYTE newOwner) {
 *********************************************************/
 void pillsMigratePlanted(pillboxes *value, BYTE oldOwner, BYTE newOwner) {
   BYTE count;    /* Looping Variable */
-  bool isServer; /* Are we a server */
 
   count = 0;
-  isServer = threadsGetContext();
   while (count < ((*value)->numPills)) {
 	if (((*value)->item[count].owner) == oldOwner) {
  	  if((*value)->item[count].inTank == FALSE){

--- a/winbolo/src/bolo/players.c
+++ b/winbolo/src/bolo/players.c
@@ -2109,9 +2109,9 @@ bool playersPrepareLogSnapshotForPlayer(players *value, BYTE playerNum, BYTE *bu
     buff[9] = utilPutNibble(lgmGetPX(lgm), lgmGetPY(lgm));
     buff[10] = lgmGetFrame(lgm);
     *len = 11;
-    utilCtoPString((*value)->item[playerNum].playerName, buff+11);
+    utilCtoPString((*value)->item[playerNum].playerName, (char*) buff+11);
     *len += buff[11]+1; /* Add 1 for len prefix */
-    utilCtoPString((*value)->item[playerNum].location, buff+*len);
+    utilCtoPString((*value)->item[playerNum].location, (char*) buff+*len);
     *len += *(buff+*len) + 1;
     *len += allianceMakeLogAlliance(&((*value)->item[playerNum].allie), buff+*len);
   }

--- a/winbolo/src/bolo/screen.c
+++ b/winbolo/src/bolo/screen.c
@@ -139,6 +139,7 @@ char brainsMessage[FILENAME_MAX]; /* Message to send */
 unsigned short brainsNumObjects;  /* Number of brain objects */
 ObjectInfo brainObjects[1024];    /* Array of brain objects  */
 
+void moveMousePointer(updateType value);
 
 /* Cursor Positions */
 int cursorPosX, cursorPosY;
@@ -2825,13 +2826,13 @@ void screenGetLgmStatus(bool *isOut, bool *isDead, TURNTYPE *angle) {
 bool screenTankScroll() {
   BYTE x;  /* Tank X and Y Co-ordinated       */
   BYTE y;
-  BYTE px; /* Pixel X and Y co-ords of the tank */
-  BYTE py;
+  //BYTE px; /* Pixel X and Y co-ords of the tank */
+  //BYTE py;
 
   x = tankGetScreenMX(&mytk);
   y = tankGetScreenMY(&mytk);
-  px = tankGetScreenPX(&mytk);
-  py = tankGetScreenPY(&mytk);
+  //px = tankGetScreenPX(&mytk);
+  //py = tankGetScreenPY(&mytk);
 /*  if (px >3 || (x - xOffset -1) == 0) {
     x++;
   }
@@ -3031,11 +3032,11 @@ void screenMakeBrainInfo(BrainInfo *value, bool first) {
 
   /* Message */
   if (messageIsNewMessage() == TRUE) {
-    unsigned long *ul;
+    //unsigned long *ul;
     value->message = (MessageInfo*) malloc(sizeof(MessageInfo));
     value->message->receivers = malloc(sizeof(value->message->receivers));
     value->message->message = malloc(512);
-    ul = value->message->receivers;
+    //ul = value->message->receivers;
     value->message->sender = messageGetNewMessage((char *) value->message->message, &(value->message->receivers)); /* FIXME: Second parameter? */
   } else {
     value->message = NULL;

--- a/winbolo/src/bolo/shells.c
+++ b/winbolo/src/bolo/shells.c
@@ -485,7 +485,7 @@ bool shellsCalcCollision(map *mp, pillboxes *pb, tank *tk, bases *bs, WORLD *xVa
 /*								} else { */
 								/* Was player get self for first owner parameter all the time */
 /*						            netMNTAdd(NMNT_KILLME, owner, screenGetTankPlayer(&(tk[count])), 0xFF, 0xFF);
-/*								 }*/
+								 }*/
 							}
 						}
 						break;

--- a/winbolo/src/bolo/tank.c
+++ b/winbolo/src/bolo/tank.c
@@ -56,6 +56,9 @@
 #include "util.h"
 
 
+int tankCalcCRCSetup(tank *value);
+netPlayers *serverNetGetNetPlayers();
+BYTE serverCoreGetTankPlayer(tank *value);
 
 bool tankShuttingDown = FALSE; // Enourmouse HACK. Please Fix Me FIXME
 BYTE ct[50];

--- a/winbolo/src/gui/linux/Makefile
+++ b/winbolo/src/gui/linux/Makefile
@@ -14,7 +14,8 @@
 # GNU General Public License for more details.
 
 
-CFLAGS = -g `sdl-config --cflags` `gtk-config --cflags` 
+CFLAGS = -g
+BOLO_CFLAGS = ${CFLAGS} `sdl-config --cflags` `gtk-config --cflags` -Wall
 LDFLAGS = `sdl-config --libs` `gtk-config --libs` `glib-config --libs gthread`
 #-s
 #CFLAGS = -s -O3 -ffast-math -fomit-frame-pointer -mpentium -march=pentium `sdl-config --cflags` `gtk-config --cflags` `glib-config --cflags` 
@@ -90,238 +91,238 @@ linbolo:    global.o bases.o util.o crc.o pillbox.o lgm.o shells.o tank.o \
 
 
 winbolonet.o: ${WBNETDIR}winbolonet.c ${WBNETDIR}winbolonet.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonet.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonet.c
 
 winbolonetthread.o: ${WBNETDIR}winbolonetthread.c ${WBNETDIR}winbolonetthread.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonetthread.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonetthread.c
 
 http.o: ${WBNETDIR}http.c ${WBNETDIR}http.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}http.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}http.c
 
 winbolonetevents.o: ${WBNETDIR}winbolonetevents.c ${WBNETDIR}winbolonetevents.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonetevents.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonetevents.c
 
 debug_file_output.o: ${BOLODIR}debug_file_output.c ${BOLODIR}debug_file_output.h
-	${CC} ${CFLAGS} -c ${BOLODIR}debug_file_output.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}debug_file_output.c
 
 
 main.o: main.c 
-	${CC} ${CFLAGS} -c main.c
+	${CC} ${BOLO_CFLAGS} -c main.c
 
 dialogkeysetup.o: dialogkeysetup.c dialogkeysetup.h 
-	${CC} ${CFLAGS} -c dialogkeysetup.c
+	${CC} ${BOLO_CFLAGS} -c dialogkeysetup.c
 
 dnslookups.o: dnslookups.c 
-	${CC} ${CFLAGS} -c dnslookups.c
+	${CC} ${BOLO_CFLAGS} -c dnslookups.c
 
 brainshandler.o: brainshandler.c
-	${CC} ${CFLAGS} -c brainshandler.c
+	${CC} ${BOLO_CFLAGS} -c brainshandler.c
 
 preferences.o: preferences.c preferences.h
-	${CC} ${CFLAGS} -c preferences.c
+	${CC} ${BOLO_CFLAGS} -c preferences.c
 
 currentgames.o: ../win32/currentgames.c ../currentgames.h
-	${CC} ${CFLAGS} -c ../win32/currentgames.c
+	${CC} ${BOLO_CFLAGS} -c ../win32/currentgames.c
 
 dialogalliance.o: dialogalliance.c dialogalliance.h
-	${CC} ${CFLAGS} -c dialogalliance.c
+	${CC} ${BOLO_CFLAGS} -c dialogalliance.c
 
 dialoggamefinder.o: dialoggamefinder.c dialoggamefinder.h
-	${CC} ${CFLAGS} -c dialoggamefinder.c
+	${CC} ${BOLO_CFLAGS} -c dialoggamefinder.c
 	
 dialogpassword.o: dialogpassword.c
-	${CC} ${CFLAGS} -c dialogpassword.c
+	${CC} ${BOLO_CFLAGS} -c dialogpassword.c
 
 dialogsetname.o: dialogsetname.c dialogsetname.h
-	${CC} ${CFLAGS} -c dialogsetname.c
+	${CC} ${BOLO_CFLAGS} -c dialogsetname.c
 
 dialoggamesetup.o: dialoggamesetup.c dialoggamesetup.h
-	${CC} ${CFLAGS} -c dialoggamesetup.c
+	${CC} ${BOLO_CFLAGS} -c dialoggamesetup.c
 
 dialogtrackersetup.o: dialogtrackersetup.c dialogtrackersetup.h
-	${CC} ${CFLAGS} -c dialogtrackersetup.c
+	${CC} ${BOLO_CFLAGS} -c dialogtrackersetup.c
 
 dialogudpsetup.o: dialogudpsetup.c
-	${CC} ${CFLAGS} -c dialogudpsetup.c
+	${CC} ${BOLO_CFLAGS} -c dialogudpsetup.c
 
 messagebox.o: messagebox.c messagebox.h
-	${CC} ${CFLAGS} -c messagebox.c
+	${CC} ${BOLO_CFLAGS} -c messagebox.c
 
 dialogsysteminfo.o: dialogsysteminfo.c dialogsysteminfo.h
-	${CC} ${CFLAGS} -c dialogsysteminfo.c
+	${CC} ${BOLO_CFLAGS} -c dialogsysteminfo.c
 
 dialogabout.o: dialogabout.c dialogabout.h
-	${CC} ${CFLAGS} -c dialogabout.c
+	${CC} ${BOLO_CFLAGS} -c dialogabout.c
 
 dialogopening.o: dialogopening.c
-	${CC} ${CFLAGS} -c dialogopening.c
+	${CC} ${BOLO_CFLAGS} -c dialogopening.c
 
 dialogmessages.o: dialogmessages.c dialogmessages.h
-	${CC} ${CFLAGS} -c dialogmessages.c
+	${CC} ${BOLO_CFLAGS} -c dialogmessages.c
 
 dialognetworkinfo.o: dialognetworkinfo.c dialognetworkinfo.h
-	${CC} ${CFLAGS} -c dialognetworkinfo.c
+	${CC} ${BOLO_CFLAGS} -c dialognetworkinfo.c
 
 dialogwinbolonet.o: dialogwinbolonet.c dialogwinbolonet.h
-	${CC} ${CFLAGS} -c dialogwinbolonet.c
+	${CC} ${BOLO_CFLAGS} -c dialogwinbolonet.c
 
 dialoggameinfo.o: dialoggameinfo.c dialoggameinfo.h
-	${CC} ${CFLAGS} -c dialoggameinfo.c
+	${CC} ${BOLO_CFLAGS} -c dialoggameinfo.c
 
 draw.o: draw.c draw.h
-	${CC} ${CFLAGS} -c draw.c
+	${CC} ${BOLO_CFLAGS} -c draw.c
 
 input.o: input.c input.h
-	${CC} ${CFLAGS} -c input.c
+	${CC} ${BOLO_CFLAGS} -c input.c
 
 sound.o: sound.c sound.h
-	${CC} ${CFLAGS} -c sound.c
+	${CC} ${BOLO_CFLAGS} -c sound.c
 
 cursor.o: cursor.c cursor.h
-	${CC} ${CFLAGS} -c cursor.c
+	${CC} ${BOLO_CFLAGS} -c cursor.c
 
 lang.o: ${GUIDIRLINUX}lang.c
 	${CC} ${CFLGS} -c ${GUIDIRLINUX}lang.c
 
 netclient.o: netclient.c
-	${CC} ${CFLAGS} -c netclient.c
+	${CC} ${BOLO_CFLAGS} -c netclient.c
 dcodlzw.o: ${COMPRESSDIR}dcodlzw.c
-	${CC} ${CFLAGS} -c ${COMPRESSDIR}dcodlzw.c
+	${CC} ${BOLO_CFLAGS} -c ${COMPRESSDIR}dcodlzw.c
 
 ecodlzw.o: ${COMPRESSDIR}ecodlzw.c
-	${CC} ${CFLAGS} -c ${COMPRESSDIR}ecodlzw.c
+	${CC} ${BOLO_CFLAGS} -c ${COMPRESSDIR}ecodlzw.c
 
 framemutex.o: framemutex.c framemutex.h
-	${CC} ${CFLAGS} -c framemutex.c
+	${CC} ${BOLO_CFLAGS} -c framemutex.c
 
 clientmutex.o: clientmutex.c ${GUIDIR}clientmutex.h
-	${CC} ${CFLAGS} -c clientmutex.c
+	${CC} ${BOLO_CFLAGS} -c clientmutex.c
 global.o: ${BOLODIR}global.c ${BOLODIR}global.h
-	${CC} ${CFLAGS} -c ${BOLODIR}global.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}global.c
 
 util.o:	${BOLODIR}util.c ${BOLODIR}util.h
-	${CC} ${CFLAGS} -c ${BOLODIR}util.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}util.c
 
 crc.o: ${BOLODIR}crc.c ${BOLODIR}crc.h
-	${CC} ${CFLAGS} -c ${BOLODIR}crc.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}crc.c
 
 backend.o: ${BOLODIR}backend.c ${BOLODIR}backend.h
-	${CC} ${CFLAGS} -c ${BOLODIR}backend.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}backend.c
 
 
 log.o: ${BOLODIR}log.c ${BOLODIR}log.h
-	${CC} ${CFLAGS} -c ${BOLODIR}log.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}log.c
 
 udppackets.o: ${BOLODIR}udppackets.c ${BOLODIR}udppackets.h
-	${CC} ${CFLAGS} -c ${BOLODIR}udppackets.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}udppackets.c
 
 bases.o: ${BOLODIR}bases.h ${BOLODIR}bases.c
-	${CC} ${CFLAGS} -c ${BOLODIR}bases.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}bases.c
 
 lgm.o: ${BOLODIR}lgm.c ${BOLODIR}lgm.h
-	${CC} ${CFLAGS} -c ${BOLODIR}lgm.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}lgm.c
 
 pillbox.o: ${BOLODIR}pillbox.c ${BOLODIR}pillbox.h
-	${CC} ${CFLAGS} -c ${BOLODIR}pillbox.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}pillbox.c
 
 shells.o: ${BOLODIR}shells.c ${BOLODIR}shells.h
-	${CC} ${CFLAGS} -c ${BOLODIR}shells.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}shells.c
 
 tank.o: ${BOLODIR}tank.c ${BOLODIR}tank.h
-	${CC} ${CFLAGS} -c ${BOLODIR}tank.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}tank.c
 
 allience.o: ${BOLODIR}allience.c ${BOLODIR}allience.h
-	${CC} ${CFLAGS} -c ${BOLODIR}allience.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}allience.c
 
 bolo_map.o: ${BOLODIR}bolo_map.c ${BOLODIR}bolo_map.h
-	${CC} ${CFLAGS} -c ${BOLODIR}bolo_map.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}bolo_map.c
 
 building.o: ${BOLODIR}building.c ${BOLODIR}building.h
-	${CC} ${CFLAGS} -c ${BOLODIR}building.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}building.c
 
 explosions.o: ${BOLODIR}explosions.c ${BOLODIR}explosions.h
-	${CC} ${CFLAGS} -c ${BOLODIR}explosions.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}explosions.c
 
 floodfill.o: ${BOLODIR}floodfill.c ${BOLODIR}floodfill.h
-	${CC} ${CFLAGS} -c ${BOLODIR}floodfill.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}floodfill.c
 
 gametype.o: ${BOLODIR}gametype.c ${BOLODIR}gametype.h
-	${CC} ${CFLAGS} -c ${BOLODIR}gametype.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}gametype.c
 
 grass.o: ${BOLODIR}grass.c ${BOLODIR}grass.h
-	${CC} ${CFLAGS} -c ${BOLODIR}grass.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}grass.c
 
 labels.o: ${BOLODIR}labels.c ${BOLODIR}labels.h
-	${CC} ${CFLAGS} -c ${BOLODIR}labels.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}labels.c
 
 messages.o: ${BOLODIR}messages.c ${BOLODIR}messages.h
-	${CC} ${CFLAGS} -c ${BOLODIR}messages.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}messages.c
 	
 mines.o: ${BOLODIR}mines.c ${BOLODIR}mines.h
-	${CC} ${CFLAGS} -c ${BOLODIR}mines.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}mines.c
 
 minesexp.o: ${BOLODIR}minesexp.c ${BOLODIR}minesexp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}minesexp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}minesexp.c
 
 netmt.o: ${BOLODIR}netmt.c ${BOLODIR}netmt.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netmt.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netmt.c
 	
 netpnb.o: ${BOLODIR}netpnb.c ${BOLODIR}netpnb.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netpnb.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netpnb.c
 
 players.o: ${BOLODIR}players.c ${BOLODIR}players.h
-	${CC} ${CFLAGS} -c ${BOLODIR}players.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}players.c
 	
 rubble.o: ${BOLODIR}rubble.c ${BOLODIR}rubble.h
-	${CC} ${CFLAGS} -c ${BOLODIR}rubble.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}rubble.c
 	
 screenbrainmap.o: ${BOLODIR}screenbrainmap.c ${BOLODIR}screenbrainmap.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenbrainmap.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenbrainmap.c
 	
 screenbullet.o: ${BOLODIR}screenbullet.c ${BOLODIR}screenbullet.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenbullet.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenbullet.c
 	
 screencalc.o: ${BOLODIR}screencalc.c ${BOLODIR}screencalc.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screencalc.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screencalc.c
 	
 screenlgm.o: ${BOLODIR}screenlgm.c ${BOLODIR}screenlgm.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenlgm.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenlgm.c
 
 screentank.o: ${BOLODIR}screentank.c ${BOLODIR}screentank.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screentank.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screentank.c
 
 scroll.o: ${BOLODIR}scroll.c ${BOLODIR}scroll.h
-	${CC} ${CFLAGS} -c ${BOLODIR}scroll.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}scroll.c
 	
 sounddist.o: ${BOLODIR}sounddist.c ${BOLODIR}sounddist.h
-	${CC} ${CFLAGS} -c ${BOLODIR}sounddist.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}sounddist.c
 
 starts.o: ${BOLODIR}starts.c ${BOLODIR}starts.h
-	${CC} ${CFLAGS} -c ${BOLODIR}starts.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}starts.c
 
 swamp.o: ${BOLODIR}swamp.c ${BOLODIR}swamp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}swamp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}swamp.c
 
 tankexp.o: ${BOLODIR}tankexp.c ${BOLODIR}tankexp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}tankexp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}tankexp.c
 
 treegrow.o: ${BOLODIR}treegrow.c ${BOLODIR}treegrow.h
-	${CC} ${CFLAGS} -c ${BOLODIR}treegrow.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}treegrow.c
 
 playersrejoin.o: ${BOLODIR}playersrejoin.c ${BOLODIR}playersrejoin.h
-	${CC} ${CFLAGS} -c ${BOLODIR}playersrejoin.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}playersrejoin.c
 
 network.o: ${BOLODIR}network.c ${BOLODIR}network.h
-	${CC} ${CFLAGS} -c ${BOLODIR}network.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}network.c
 
 screen.o: ${BOLODIR}screen.c ${BOLODIR}screen.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screen.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screen.c
 
 mathWinbolo.o: ${BOLODIR}mathWinbolo.c ${BOLODIR}mathWinbolo.h
-	${CC} ${CFLAGS} -c ${BOLODIR}mathWinbolo.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}mathWinbolo.c
 
 netplayers.o: ${BOLODIR}netplayers.c ${BOLODIR}netplayers.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netplayers.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netplayers.c
 
 
 
@@ -386,15 +387,15 @@ bigdRand.o: $(BDDIR)bigdRand.h
 
 # Server
 servercore.o: ${SERVERDIR}servercore.c ${SERVERDIR}servercore.h
-	${CC} ${CFLAGS} -c ${SERVERDIR}servercore.c
+	${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}servercore.c
 
 servermessages.o: ${SERVERDIR}servermessages.c ${BOLODIR}messages.h
-	${CC} ${CFLAGS} -c ${SERVERDIR}servermessages.c
+	${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}servermessages.c
 servernet.o: ${SERVERDIR}servernet.c ${SERVERDIR}servernet.h ${SERVERDIR}rsaalgorithm.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}servernet.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}servernet.c
 servertransport.o: ${SERVERDIR}servertransport.c ${SERVERDIR}servertransport.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}servertransport.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}servertransport.c
 
 threads.o: ${SERVERDIR}threads.c ${SERVERDIR}threads.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}threads.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}threads.c
 

--- a/winbolo/src/gui/linux/Makefile
+++ b/winbolo/src/gui/linux/Makefile
@@ -187,10 +187,10 @@ lang.o: ${GUIDIRLINUX}lang.c
 netclient.o: netclient.c
 	${CC} ${BOLO_CFLAGS} -c netclient.c
 dcodlzw.o: ${COMPRESSDIR}dcodlzw.c
-	${CC} ${BOLO_CFLAGS} -c ${COMPRESSDIR}dcodlzw.c
+	${CC} ${CFLAGS} -c ${COMPRESSDIR}dcodlzw.c
 
 ecodlzw.o: ${COMPRESSDIR}ecodlzw.c
-	${CC} ${BOLO_CFLAGS} -c ${COMPRESSDIR}ecodlzw.c
+	${CC} ${CFLAGS} -c ${COMPRESSDIR}ecodlzw.c
 
 framemutex.o: framemutex.c framemutex.h
 	${CC} ${BOLO_CFLAGS} -c framemutex.c

--- a/winbolo/src/gui/linux/brainshandler.c
+++ b/winbolo/src/gui/linux/brainshandler.c
@@ -92,7 +92,6 @@ bool brainsHandlerStart(HWND hWnd, char *str, char *name);
 
 void brainsHandlerSelect(GtkWidget *widget, gpointer user_data) {
   char str[MAX_PATH];  /* Path to the brain to run */
-  int ret;             /* Function return value    */
   FILE *fp;
   gchar *menuStr;
 
@@ -314,7 +313,7 @@ void brainsHandlerSet(HWND hWnd, bool enabled) {
   int    nIndex;
   GSList *node;
   GtkWidget *w;
-  for (nIndex = 0; node = g_slist_nth (brainsLoadedList, nIndex); nIndex++) {
+  for (nIndex = 0; (node = g_slist_nth (brainsLoadedList, nIndex)); nIndex++) {
     w = (GtkWidget *) node->data;
     gtk_widget_set_sensitive(w, enabled);
   }

--- a/winbolo/src/gui/linux/clientmutex.c
+++ b/winbolo/src/gui/linux/clientmutex.c
@@ -52,7 +52,6 @@ HANDLE hClientMutexHandle = NULL;
 *
 *********************************************************/
 bool clientMutexCreate(void) {
-  char name[FILENAME_MAX];
   bool returnValue; /* Value to return */
 
   returnValue = TRUE;

--- a/winbolo/src/gui/linux/cursor.c
+++ b/winbolo/src/gui/linux/cursor.c
@@ -217,12 +217,12 @@ bool cursorPos(int mouseX, int mouseY, BYTE *xValue, BYTE *yValue) {
 *  rcWindow - Rect with the windows co-ordinates
 *********************************************************/
 void cursorAcquireCursor() {
-  int xPos;        /* X and Y positions of the mouse adjusted */ 
-  int yPos;        /* to the window */
-  BYTE zoomFactor; /* The zooming factor */
-
   return;
   /* FIXME: Is relevent?
+  int xPos;        // X and Y positions of the mouse adjusted
+  int yPos;        // to the window
+  BYTE zoomFactor; // The zooming factor
+
   GetCursorPos(&mousePos);
   zoomFactor = windowGetZoomFactor();
 

--- a/winbolo/src/gui/linux/dialogabout.c
+++ b/winbolo/src/gui/linux/dialogabout.c
@@ -41,6 +41,7 @@ gboolean dialogAboutFunc(GtkWidget *widget,  GdkEventButton *event, gpointer use
   gtk_grab_remove(dialogAboutUs);
   gtk_widget_destroy(dialogAboutUs);
   gtk_main_quit();
+  return FALSE;
 }
 
 GtkWidget* dialogAboutCreate(void) {

--- a/winbolo/src/gui/linux/dialogalliance.c
+++ b/winbolo/src/gui/linux/dialogalliance.c
@@ -27,6 +27,7 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include "../../bolo/global.h"
+#include "../../bolo/network.h"
 #include "../linresource.h"
 #include "../lang.h"
 

--- a/winbolo/src/gui/linux/dialoggamefinder.c
+++ b/winbolo/src/gui/linux/dialoggamefinder.c
@@ -72,6 +72,8 @@ GtkWidget *idc_gamefindmapname;
 bool dialogGameFinderClosing = FALSE;
 
 gboolean dialogGameFinderSelect(GtkWidget *widget, gpointer user_data);
+bool netClientFindBroadcastGames(GtkWidget *hWnd, currentGames *cg);
+bool netClientFindTrackedGames(GtkWidget *hWnd, currentGames *cg, char *trackerAddress, unsigned short port, char *motd);
 
 
 /*********************************************************

--- a/winbolo/src/gui/linux/dialoggameinfo.c
+++ b/winbolo/src/gui/linux/dialoggameinfo.c
@@ -109,7 +109,6 @@ GtkWidget* dialogGameInfoCreate(void) {
   char mapName[FILENAME_MAX];  /* Map Name */
   int temp;                    /* Used to hold various values */
   bool bTemp;                  /* Used for holding misc bool variables */
-  char *text;
   gameType *t;
 	
   dialogGameInfo = gtk_window_new (GTK_WINDOW_DIALOG);

--- a/winbolo/src/gui/linux/dialoggamesetup.c
+++ b/winbolo/src/gui/linux/dialoggamesetup.c
@@ -167,7 +167,6 @@ gboolean dialogGameSetupStartDelay(GtkWidget *widget,  GdkEventButton *event, gp
 }
 
 gboolean dialogGameSetupShow(GtkWidget *widget,  GdkEventButton *event, gpointer user_data) {
-  char fileName[FILENAME_MAX]; /* Name of the map              */
   char password[FILENAME_MAX]; /* Dialog Options               */
   gameType gt;
   bool hm;
@@ -250,6 +249,7 @@ gboolean dialogGameSetupShow(GtkWidget *widget,  GdkEventButton *event, gpointer
 
   }
   gtk_label_set_text(GTK_LABEL(idc_gamesetupselectedmap), "Selected Map: Everard Island (inbuilt)");
+  return FALSE;
 }
 
 gboolean dialogGameSetupOK(GtkWidget *widget,  GdkEventButton *event, gpointer user_data) {

--- a/winbolo/src/gui/linux/dialogmessages.c
+++ b/winbolo/src/gui/linux/dialogmessages.c
@@ -70,6 +70,7 @@
   /* Print it */
   gtk_label_set_text(GTK_LABEL(idc_label), output);
 
+  return FALSE;
 } 
 
 
@@ -124,6 +125,7 @@ gboolean dialogMessagesClose(GtkWidget *widget,  GdkEventButton *event, gpointer
   }
   windowMessagesClose();
   gtk_widget_destroy(widget);
+  return FALSE;
 }
 
 GtkWidget*

--- a/winbolo/src/gui/linux/dialogopening.c
+++ b/winbolo/src/gui/linux/dialogopening.c
@@ -110,7 +110,6 @@ GtkWidget* dialogOpeningCreate(void) {
   GtkWidget *idc_openok;
   GdkPixmap *pixmap_data;
   GdkPixmap *pixmap_mask;
-  GtkWidget *pixw;
 
   
   dialogOpening = gtk_window_new (GTK_WINDOW_DIALOG);

--- a/winbolo/src/gui/linux/dialogsysteminfo.c
+++ b/winbolo/src/gui/linux/dialogsysteminfo.c
@@ -52,6 +52,12 @@ GtkWidget *lblFPS;
 
 int sysInfoTimer;
 
+int drawGetFrameRate();
+int windowGetDrawTime(void);
+int windowGetSimTime(void);
+int windowGetNetTime(void);
+int windowGetAiTime(void);
+
 /*********************************************************
 *NAME:          dialogSysInfoUpdate
 *AUTHOR:        John Morrison

--- a/winbolo/src/gui/linux/dialogudpsetup.c
+++ b/winbolo/src/gui/linux/dialogudpsetup.c
@@ -131,6 +131,7 @@ gboolean dialogUdpSetupShow(GtkWidget *widget,  GdkEventButton *event, gpointer 
   gtk_entry_set_text(GTK_ENTRY(idc_udpmachinename), add);
 
   gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(idc_updsetupremembername), gameFrontGetRemeber());
+  return FALSE;
 }
 
 gboolean dialogUdpSetupReJoin(GtkWidget *widget,  GdkEventButton *event, gpointer user_data) {

--- a/winbolo/src/gui/linux/dialogwinbolonet.c
+++ b/winbolo/src/gui/linux/dialogwinbolonet.c
@@ -36,6 +36,8 @@ GtkWidget *dialogWbnUse;
 GtkWidget *dialogWbnSavePass;
 GtkWidget *dialogWbnPassword;
 
+void gameFrontGetPlayerName(char *pn);
+
 void dialogWinboloNetCloseBox(GtkWidget *widget, gpointer user_data) {
   gtk_widget_destroy(dialogWbnUs);
   gtk_main_quit();

--- a/winbolo/src/gui/linux/dnslookups.c
+++ b/winbolo/src/gui/linux/dnslookups.c
@@ -33,6 +33,7 @@
 	#include "SDL_thread.h"
 	typedef SDL_mutex *HANDLE;
 #endif
+#include <unistd.h>
 #include <string.h>
 #include "../../bolo/global.h"
 #include "../netclient.h"
@@ -171,7 +172,6 @@ void dnsLookupsAddRequest(char *ip, void *func) {
 int dnsLookupsRun() {
   char dest[512]; /* Destination address space */
   dnsList q;      /* Used to iterate through the list */
-  void *func;   /* Function to call */
 
   while (dnsShouldRun == TRUE) {
     SDL_mutexP(hDnsMutexHandle);

--- a/winbolo/src/gui/linux/framemutex.c
+++ b/winbolo/src/gui/linux/framemutex.c
@@ -52,7 +52,6 @@ HANDLE hFrameMutexHandle = NULL;
 *
 *********************************************************/
 bool frameMutexCreate(void) {
-  char name[FILENAME_MAX];
   bool returnValue; /* Value to return */
 
   returnValue = TRUE;

--- a/winbolo/src/gui/linux/input.c
+++ b/winbolo/src/gui/linux/input.c
@@ -178,8 +178,6 @@ tankButton inputGetKeys(bool isMenu) {
 *  isMenu  - True if we are in a menu
 *********************************************************/
 void inputScroll(bool isMenu) {
-  bool proceed; /* Ok to proceed */
-
   scrollKeyCount++;
   if (scrollKeyCount >= INPUT_SCROLL_WAIT_TIME && isMenu == FALSE) {
     scrollKeyCount = 0;

--- a/winbolo/src/gui/linux/main.c
+++ b/winbolo/src/gui/linux/main.c
@@ -209,6 +209,16 @@ gchar *applicationPath;
 void windowStartTutorial();
 void menus(GtkWidget *window);
 bool brainsHandlerLoadBrains(GtkWidget *hWnd);
+void brainsHandlerManual(GtkWidget *hWnd);
+void clientMutexWaitFor(void);
+void clientMutexRelease(void);
+bool brainHandlerIsBrainRunning();
+void brainHandlerRun(GtkWidget *hWnd);
+void brainsHandlerSet(GtkWidget *hWnd, bool enabled);
+bool clientMutexCreate(void);
+void clientMutexDestroy(void);
+void drawDownloadScreen(void *rcWindow, bool justBlack);
+void drawSetManClear(void);
 
 void gameFrontCloseServer();
 int frameRateTime = (int) (MILLISECONDS / FRAME_RATE_30) - 1;
@@ -367,6 +377,7 @@ gboolean release_event(GtkWidget *widget, GdkEventKey *event, gpointer user_data
 
 gint windowLoseFocus(GtkWidget *widget, gpointer data) {
   gdk_key_repeat_restore();
+  return 0;
 }
 
 gint windowGetFocus(GtkWidget *widget, gpointer data) {
@@ -380,6 +391,7 @@ gint windowGetFocus(GtkWidget *widget, gpointer data) {
    frameMutexRelease();
    clientMutexRelease();
   gdk_key_repeat_disable();
+  return 0;
 }
 
 /* The frame rate */
@@ -395,8 +407,6 @@ Uint32 windowGameTimer (Uint32 interval, void *param) {
   static bool justKeys = FALSE; /* Just the keys tick or whole game? */
   static BYTE t2 = 0;
   static int trackerTime = 11500;   /* When we should update the tracker */
-  SDL_Rect rcWindow;
-  DWORD tick;     /* Number of ticks passed */
   tankButton tb;  /* Buttons being pressed */
   bool isShoot;   /* Whether the tank fire key is being pressed */
   bool used = FALSE;
@@ -1293,7 +1303,6 @@ void catch_alarm (int sig) {
 
 
 int main(int argc, char **argv) {
-  int ret;
   char SDL_windowhack[32];
   GtkWidget *dialogOpening;
   gchar *mkDirPath;
@@ -1413,6 +1422,7 @@ bool startSinglePlayer() {
     sendBackendMenuOptions();
     startTimers();
  }
+ return FALSE;
 }
 
 /*********************************************************
@@ -2382,10 +2392,8 @@ BYTE upTo = 0;
 
 bool frontEndTutorial(BYTE pos) {
   bool returnValue; /* Value to return */
-  bool flag;
   
 
-  flag = FALSE;
  // gdk_threads_enter();
   returnValue = FALSE;
   if (isTutorial == TRUE) {
@@ -3288,7 +3296,7 @@ on_manual1_activate                    (GtkMenuItem     *menuitem,
 {
   if (isInMenu == FALSE) {
     isInMenu = TRUE;
-    brainsHandlerManual();
+    brainsHandlerManual(NULL);
     isInMenu = FALSE;
   } 
 }
@@ -3343,7 +3351,7 @@ void menus(GtkWidget *window) {
   GtkWidget *vbox1;
   GtkWidget *file1;
   GtkWidget *file1_menu;
-  GtkAccelGroup *file1_menu_accels;
+  //GtkAccelGroup *file1_menu_accels;
   GtkWidget *new1;
   GtkWidget *save_map1;
   GtkWidget *separator1;
@@ -3355,10 +3363,10 @@ GtkWidget *background_sound1;
   GtkWidget *exit1;
   GtkWidget *edit1;
   GtkWidget *edit1_menu;
-  GtkAccelGroup *edit1_menu_accels;
+  //GtkAccelGroup *edit1_menu_accels;
   GtkWidget *frame_rate1;
   GtkWidget *frame_rate1_menu;
-  GtkAccelGroup *frame_rate1_menu_accels;
+  //GtkAccelGroup *frame_rate1_menu_accels;
   GSList *_2_group = NULL;
   GtkWidget *_4;
   GtkWidget *_8;
@@ -3369,20 +3377,20 @@ GtkWidget *background_sound1;
   GtkWidget *_14;
   GtkWidget *window_size1;
   GtkWidget *window_size1_menu;
-  GtkAccelGroup *window_size1_menu_accels;
+  //GtkAccelGroup *window_size1_menu_accels;
   GSList *_3_group = NULL;
   GtkWidget *normal1;
   GtkWidget *double1;
   GtkWidget *quad1;
   GtkWidget *message_sender_names1;
   GtkWidget *message_sender_names1_menu;
-  GtkAccelGroup *message_sender_names1_menu_accels;
+  //GtkAccelGroup *message_sender_names1_menu_accels;
   GSList *_0_group = NULL;
   GtkWidget *short1;
   GtkWidget *long1;
   GtkWidget *tank_labels1;
   GtkWidget *tank_labels1_menu;
-  GtkAccelGroup *tank_labels1_menu_accels;
+  //GtkAccelGroup *tank_labels1_menu_accels;
   GSList *_1_group = NULL;
   GtkWidget *none1;
   GtkWidget *short2;
@@ -3394,7 +3402,7 @@ GtkWidget *background_sound1;
   GtkWidget *hide_main_view1;
   GtkWidget *linbolo1;
   GtkWidget *linbolo1_menu;
-  GtkAccelGroup *linbolo1_menu_accels;
+  //GtkAccelGroup *linbolo1_menu_accels;
   GtkWidget *allow_new_players1;
   GtkWidget *allow_alliance_request1;
   GtkWidget *set_keys1;
@@ -3408,7 +3416,7 @@ GtkWidget *background_sound1;
   GtkWidget *separator6;
   GtkWidget *players1;
   GtkWidget *players1_menu;
-  GtkAccelGroup *players1_menu_accels;
+  //GtkAccelGroup *players1_menu_accels;
   GtkWidget *send_message1;
   GtkWidget *separator7;
   GtkWidget *select_all1;
@@ -3417,11 +3425,11 @@ GtkWidget *background_sound1;
   GtkWidget *select_nearby_tanks1;
   GtkWidget *separator8;
   GtkWidget *brains1;
-  GtkAccelGroup *brains1_menu_accels;
+  //GtkAccelGroup *brains1_menu_accels;
   GtkWidget *separator9;
   GtkWidget *help1;
   GtkWidget *help1_menu;
-  GtkAccelGroup *help1_menu_accels;
+  //GtkAccelGroup *help1_menu_accels;
   GtkWidget *help2;
   GtkWidget *about1;
   GtkAccelGroup *accel_group;
@@ -3458,7 +3466,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "file1_menu", file1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (file1), file1_menu);
-  file1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (file1_menu));
+  /*file1_menu_accels =*/ gtk_menu_ensure_uline_accel_group (GTK_MENU (file1_menu));
 
   new1 = gtk_menu_item_new_with_label ("New");
   gtk_widget_ref (new1);
@@ -3536,7 +3544,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "edit1_menu", edit1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (edit1), edit1_menu);
-  edit1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (edit1_menu));
+  /*edit1_menu_accels =*/ gtk_menu_ensure_uline_accel_group (GTK_MENU (edit1_menu));
 
   frame_rate1 = gtk_menu_item_new_with_label ("Frame Rate");
   gtk_widget_ref (frame_rate1);
@@ -3550,7 +3558,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "frame_rate1_menu", frame_rate1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (frame_rate1), frame_rate1_menu);
-  frame_rate1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (frame_rate1_menu));
+  /*frame_rate1_menu_accels =*/ gtk_menu_ensure_uline_accel_group (GTK_MENU (frame_rate1_menu));
 
   _4 = gtk_radio_menu_item_new_with_label (_2_group, "60");
   _2_group = gtk_radio_menu_item_group (GTK_RADIO_MENU_ITEM (_4));
@@ -3621,7 +3629,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "window_size1_menu", window_size1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (window_size1), window_size1_menu);
-  window_size1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (window_size1_menu));
+  /*window_size1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (window_size1_menu));
 
   normal1 = gtk_radio_menu_item_new_with_label (_3_group, "Normal");
   _3_group = gtk_radio_menu_item_group (GTK_RADIO_MENU_ITEM (normal1));
@@ -3680,7 +3688,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "message_sender_names1_menu", message_sender_names1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (message_sender_names1), message_sender_names1_menu);
-  message_sender_names1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (message_sender_names1_menu));
+  /*message_sender_names1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (message_sender_names1_menu));
 
   short1 = gtk_radio_menu_item_new_with_label (_0_group, "Short");
   _0_group = gtk_radio_menu_item_group (GTK_RADIO_MENU_ITEM (short1));
@@ -3711,7 +3719,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "tank_labels1_menu", tank_labels1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (tank_labels1), tank_labels1_menu);
-  tank_labels1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (tank_labels1_menu));
+  /*tank_labels1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (tank_labels1_menu));
 
   none1 = gtk_radio_menu_item_new_with_label (_1_group, "None");
   _1_group = gtk_radio_menu_item_group (GTK_RADIO_MENU_ITEM (none1));
@@ -3804,7 +3812,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "linbolo1_menu", linbolo1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (linbolo1), linbolo1_menu);
-  linbolo1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (linbolo1_menu));
+  /*linbolo1_menu_accels =*/ gtk_menu_ensure_uline_accel_group (GTK_MENU (linbolo1_menu));
 
   allow_new_players1 = gtk_check_menu_item_new_with_label ("Allow New Players");
   gtk_widget_ref (allow_new_players1);
@@ -3943,7 +3951,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "players1_menu", players1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (players1), players1_menu);
-  players1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (players1_menu));
+  /*players1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (players1_menu));
 
   send_message1 = gtk_menu_item_new_with_label ("Send Message");
   gtk_widget_ref (send_message1);
@@ -4125,7 +4133,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "brains1_menu", brains1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (brains1), brains1_menu);
-  brains1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (brains1_menu));
+  /*brains1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (brains1_menu));
 
   manual1 = gtk_radio_menu_item_new_with_label (brainsGroup, "Manual");
   brainsGroup = gtk_radio_menu_item_group (GTK_RADIO_MENU_ITEM (manual1));
@@ -4157,7 +4165,7 @@ GtkWidget *background_sound1;
   gtk_object_set_data_full (GTK_OBJECT (window), "help1_menu", help1_menu,
                             (GtkDestroyNotify) gtk_widget_unref);
   gtk_menu_item_set_submenu (GTK_MENU_ITEM (help1), help1_menu);
-  help1_menu_accels = gtk_menu_ensure_uline_accel_group (GTK_MENU (help1_menu));
+  /*help1_menu_accels = */gtk_menu_ensure_uline_accel_group (GTK_MENU (help1_menu));
 
   help2 = gtk_menu_item_new_with_label ("Help");
   gtk_widget_ref (help2);

--- a/winbolo/src/gui/linux/netclient.c
+++ b/winbolo/src/gui/linux/netclient.c
@@ -61,6 +61,8 @@ typedef GtkWidget HWND;
 #include "../../bolo/network.h"
 #include "../../bolo/netpacks.h"
 #include "../../bolo/udppackets.h"
+#include "../../bolo/crc.h"
+#include "../../bolo/util.h"
 #include "../linresource.h"
 #include "../lang.h"
 #include "../netclient.h"
@@ -135,7 +137,7 @@ bool netClientCreate(unsigned short port) {
       MessageBox(NULL, langGetText(STR_NETCLIENTERR_BINDUDPFAIL), DIALOG_BOX_TITLE, MB_ICONINFORMATION);
     } else {
       /* Get what port we were assigned */
-      if (getsockname(myUdpSock, (struct sockaddr*) &name, &nameLen) == 0) {
+      if (getsockname(myUdpSock, (struct sockaddr*) &name, (socklen_t *)&nameLen) == 0) {
         myPort = ntohs(name.sin_port);
       }
     }
@@ -391,7 +393,7 @@ bool netClientUdpPingServer(BYTE *buff, int *len, bool wantCrc, bool addNonRelia
   sendto(myUdpSock, (char *) buff, *len, 0, (struct sockaddr *)&addrServer, sizeof(addrServer));
   *len = 0;
   while (*len <= 0 && timeOut <= TIME_OUT) {
-    *len = recvfrom(myUdpSock, (char *) buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, &fromlen);
+    *len = recvfrom(myUdpSock, (char *) buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, (socklen_t*)&fromlen);
 /*      if (*len == SOCKET_ERROR) {
       if (WSAGetLastError() != WSAEWOULDBLOCK ) {
 Do we want to bail out? I don't think so
@@ -465,7 +467,7 @@ bool netClientUdpPing(BYTE *buff, int *len, char *dest, unsigned short port, boo
     sendto(myUdpSock, (char *) buff, *len, 0, (struct sockaddr *)&addr, sizeof(addr));
     *len = 0;
     while (*len <= 0 && timeOut <= TIME_OUT) {
-      *len = recvfrom(myUdpSock, (char *) buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, &fromlen);
+      *len = recvfrom(myUdpSock, (char *) buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, (socklen_t*)&fromlen);
 /*      if (*len == SOCKET_ERROR) {
         if (WSAGetLastError() != WSAEWOULDBLOCK ) {
  Do we want to bail out? I don't think so
@@ -585,13 +587,13 @@ void netClientUdpCheck(void) {
   struct sockaddr_in from;
   int fromlen = sizeof(from);
 
-  packetLen = recvfrom(myUdpSock, info, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, &fromlen);
+  packetLen = recvfrom(myUdpSock, info, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, (socklen_t *)&fromlen);
   while (packetLen > 0) {
     /* We have data - Yah! */
     memcpy(&addrLast, &from, (size_t) sizeof(from));
     lastPort = from.sin_port;
     netUdpPacketArrive((BYTE *) info, packetLen, lastPort);
-    packetLen = recvfrom(myUdpSock, info, sizeof(info), 0, (struct sockaddr *)&from, &fromlen);
+    packetLen = recvfrom(myUdpSock, info, sizeof(info), 0, (struct sockaddr *)&from, (socklen_t *)&fromlen);
   }
 }
 
@@ -760,7 +762,6 @@ bool gameFinderYesNoToBool(char *str) {
 void gameFinderProcessV1(currentGames *cg, char *buff, int len, char *motd) {
   char param[1024];
   char *ptr;
-  char *ptr2;
   int numMotdLines = 0;
   int count = 0;
   int numGames;
@@ -779,7 +780,6 @@ void gameFinderProcessV1(currentGames *cg, char *buff, int len, char *motd) {
   aiType ai;
 
   ptr = buff;
-  ptr2 = buff;
   if (gameFinderGetParamFromLine(buff, param, "MOTDL") != -1) {
     /* Process Message of the day */
     numMotdLines = atoi(param);
@@ -968,10 +968,10 @@ bool netClientFindTrackedGames(HWND *hWnd, currentGames *cg, char *trackerAddres
   ptr = b;
 
 
-  strcpy(buff, "Status: ");
-  strcat(buff, langGetText(STR_NETCLIENT_TRACKERCONNECT));
+  strcpy((char *) buff, "Status: ");
+  strcat((char *) buff, langGetText(STR_NETCLIENT_TRACKERCONNECT));
   sprintf(strBuff, "%s:%d", trackerAddress, port);
-  strcat(buff, strBuff);
+  strcat((char *) buff, strBuff);
   gtk_label_set_text(GTK_LABEL(hWnd), (char *) buff);
   GDK_THREADS_LEAVE();
   while(g_main_iteration(FALSE));
@@ -1054,7 +1054,7 @@ bool netClientFindTrackedGames(HWND *hWnd, currentGames *cg, char *trackerAddres
     } else {
       sprintf(txt, "Status: %s", langGetText(STR_NETCLIENT_TRACKERPROCESSRESPONSE));
       gtk_label_set_text(GTK_LABEL(hWnd), txt);
-      gameFinderProcess(hWnd, cg, b, len, motd);
+      gameFinderProcess(hWnd, cg, (char *)b, len, motd);
     }
  }
 
@@ -1083,7 +1083,7 @@ bool netClientFindBroadcastGames(HWND *hWnd, currentGames *cg) {
   SOCKET sock;             /* Socket to use    */
   BYTE *ptr;               /* Buffer pointer */
   int len = 0;
-  char buff[MAX_UDPPACKET_SIZE] = INFOREQUESTHEADER; /* Data Buffer */
+  BYTE buff[MAX_UDPPACKET_SIZE] = INFOREQUESTHEADER; /* Data Buffer */
   int timeOut;
   DWORD tick;
   int fromlen;
@@ -1154,12 +1154,12 @@ bool netClientFindBroadcastGames(HWND *hWnd, currentGames *cg) {
     /* Get responses */
     sprintf(txt, "Status: %s", langGetText(STR_NETCLIENT_GETRESPONSES));
     gtk_label_set_text(GTK_LABEL(hWnd), txt);
-    len = recvfrom(sock, ptr+len, sizeof(buff)-len, 0, (struct sockaddr *) &last, &szlast);
+    len = recvfrom(sock, ptr+len, sizeof(buff)-len, 0, (struct sockaddr *) &last, (socklen_t*)&szlast);
     timeOut = 0;
     tick = timeGetTime();
     while (timeOut <= 10000) { //TIME_OUT
       if (len == sizeof(INFO_PACKET)) {
-        if (strncmp(buff, BOLO_SIGNITURE, BOLO_SIGNITURE_SIZE) == 0 && buff[BOLO_VERSION_MAJORPOS] == BOLO_VERSION_MAJOR && buff[BOLO_VERSION_MINORPOS] == BOLO_VERSION_MINOR && buff[BOLO_VERSION_REVISIONPOS] == BOLO_VERSION_REVISION && buff[BOLOPACKET_REQUEST_TYPEPOS] == BOLOPACKET_INFORESPONSE) {
+        if (strncmp((char *) buff, BOLO_SIGNITURE, BOLO_SIGNITURE_SIZE) == 0 && buff[BOLO_VERSION_MAJORPOS] == BOLO_VERSION_MAJOR && buff[BOLO_VERSION_MINORPOS] == BOLO_VERSION_MINOR && buff[BOLO_VERSION_REVISIONPOS] == BOLO_VERSION_REVISION && buff[BOLOPACKET_REQUEST_TYPEPOS] == BOLOPACKET_INFORESPONSE) {
         /* Process response */
           gameFinderProcessBroadcast(cg, (INFO_PACKET *) buff, &(last.sin_addr));
         }
@@ -1169,7 +1169,7 @@ bool netClientFindBroadcastGames(HWND *hWnd, currentGames *cg) {
       GDK_THREADS_ENTER();
       usleep(50);
       timeOut = timeGetTime() - tick;
-      len = recvfrom(sock, buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, &fromlen);
+      len = recvfrom(sock, buff, MAX_UDPPACKET_SIZE, 0, (struct sockaddr *)&from, (socklen_t*)&fromlen);
     }
   }
   if (sock != INVALID_SOCKET) {

--- a/winbolo/src/gui/linux/netclient.c
+++ b/winbolo/src/gui/linux/netclient.c
@@ -209,7 +209,7 @@ void netClientSendUdpServer(BYTE *buff, int len) {
 *  port - Port of that corresponds to the address
 *********************************************************/
 void netClientGetServerAddress(struct in_addr *dest, unsigned short *port) {
-  memcpy(dest, &(addrServer.sin_addr.s_addr), sizeof(dest));
+  memcpy(dest, &(addrServer.sin_addr.s_addr), sizeof(*dest));
   *port = ntohs(addrServer.sin_port);
 }
 
@@ -248,7 +248,7 @@ void netClientGetServerAddressString(char *dest) {
 *  port - Port of that corresponds to the address
 *********************************************************/
 void netClientSetServerAddress(struct in_addr *src, unsigned short port) {
-  memcpy(&(addrServer.sin_addr.s_addr), src, sizeof(src)); 
+  memcpy(&(addrServer.sin_addr.s_addr), src, sizeof(*src)); 
   addrServer.sin_port = htons(port);
 }
 
@@ -608,7 +608,6 @@ void netClientUdpCheck(void) {
 *  on - TRUE for non-block, FALSE for blocking
 *********************************************************/
 bool netClientSetUdpAsync(bool on) {
-  u_long noBlock;   /* Used to set blocking state */
   int ret;          /* Function return value */
   bool returnValue; /* Value to return */
   
@@ -959,7 +958,6 @@ bool netClientFindTrackedGames(HWND *hWnd, currentGames *cg, char *trackerAddres
   int len = 0;
   int new_bytes_read;
   char strBuff[FILENAME_MAX];
-  long noBlock;     /* Used to set blocking state */
   bool done;
   DWORD tick, timeOut;
   char txt[256];
@@ -974,7 +972,7 @@ bool netClientFindTrackedGames(HWND *hWnd, currentGames *cg, char *trackerAddres
   strcat(buff, langGetText(STR_NETCLIENT_TRACKERCONNECT));
   sprintf(strBuff, "%s:%d", trackerAddress, port);
   strcat(buff, strBuff);
-  gtk_label_set_text(GTK_LABEL(hWnd), buff);
+  gtk_label_set_text(GTK_LABEL(hWnd), (char *) buff);
   GDK_THREADS_LEAVE();
   while(g_main_iteration(FALSE));
   GDK_THREADS_ENTER();
@@ -1016,7 +1014,6 @@ bool netClientFindTrackedGames(HWND *hWnd, currentGames *cg, char *trackerAddres
     }
   }
 
-  noBlock = NO_BLOCK_SOCK;
   if (returnValue == TRUE) {
     ret = fcntl(sock, F_SETFL, O_NONBLOCK | fcntl(sock, F_GETFL));
     if (ret == SOCKET_ERROR) {
@@ -1087,7 +1084,6 @@ bool netClientFindBroadcastGames(HWND *hWnd, currentGames *cg) {
   BYTE *ptr;               /* Buffer pointer */
   int len = 0;
   char buff[MAX_UDPPACKET_SIZE] = INFOREQUESTHEADER; /* Data Buffer */
-  long noBlock;     /* Used to set blocking state */
   int timeOut;
   DWORD tick;
   int fromlen;
@@ -1122,7 +1118,6 @@ bool netClientFindBroadcastGames(HWND *hWnd, currentGames *cg) {
 
   /* Set to non blocking */
   if (returnValue == TRUE) {
-    noBlock = NO_BLOCK_SOCK;
      ret = fcntl(sock, F_SETFL, O_NONBLOCK | fcntl(sock, F_GETFL));
      if (ret == SOCKET_ERROR) {
       returnValue = FALSE;

--- a/winbolo/src/gui/linux/preferences.c
+++ b/winbolo/src/gui/linux/preferences.c
@@ -19,6 +19,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <pwd.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "../../bolo/global.h"

--- a/winbolo/src/gui/linux/sound.c
+++ b/winbolo/src/gui/linux/sound.c
@@ -106,10 +106,8 @@ Mix_Chunk *soundLoad(char *tempFile, FILE *fp, BYTE *buff, int len) {
 bool soundSetup() {
   bool returnValue;       /* Value to return */
   bool dsLoadOK;
-  gchar *tmpPath;
   char fileName[FILENAME_MAX];
   char inFile[FILENAME_MAX];
-  char *tf;
   FILE *in;
   BYTE *buff;
 

--- a/winbolo/src/server/Makefile
+++ b/winbolo/src/server/Makefile
@@ -27,7 +27,8 @@ REM = rm
 # Flags for gcc and rm
 REMFLAGS = -f
 LDFLAGS = `sdl-config --libs` -lm
-CFLAGS = `sdl-config --cflags` -DHAVE_C99INCLUDES -DHAVE_SYS_TYPES
+CFLAGS =
+BOLO_CFLAGS = $(CFLAGS) `sdl-config --cflags` -DHAVE_C99INCLUDES -DHAVE_SYS_TYPES -Wall
 BDFLAGS = -DHAVE_C99INCLUDES -std=c99 -pedantic -Wall -Wpointer-arith -Wstrict-prototypes -O2
 
 # directories
@@ -154,124 +155,124 @@ zutil.o: ${ZLIBDIR}zutil.c
 # gui lang
 #
 lang.o: ${GUIDIRLINUX}lang.c ${GUIDIR}lang.h
-	${CC} ${CFLAGS} -c ${GUIDIRLINUX}lang.c
+	${CC} ${BOLO_CFLAGS} -c ${GUIDIRLINUX}lang.c
 preferences.o: ${GUIDIRLINUX}preferences.c ${GUIDIRLINUX}preferences.h
-	${CC} ${CFLAGS} -c ${GUIDIRLINUX}preferences.c
+	${CC} ${BOLO_CFLAGS} -c ${GUIDIRLINUX}preferences.c
 
 # winbolonet
 winbolonet.o: ${WBNETDIR}winbolonet.c ${WBNETDIR}winbolonet.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonet.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonet.c
 winbolonetevents.o: ${WBNETDIR}winbolonetevents.c ${WBNETDIR}winbolonetevents.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonetevents.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonetevents.c
 winbolonetthread.o: ${WBNETDIR}winbolonetthread.c ${WBNETDIR}winbolonetthread.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}winbolonetthread.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}winbolonetthread.c
 
 
 http.o: ${WBNETDIR}http.c ${WBNETDIR}http.h
-	${CC} ${CFLAGS} -c ${WBNETDIR}http.c
+	${CC} ${BOLO_CFLAGS} -c ${WBNETDIR}http.c
 
 # Bolo
 global.o: ${BOLODIR}global.c ${BOLODIR}global.h
-	${CC} ${CFLAGS} -c ${BOLODIR}global.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}global.c
 
 backend.o: ${BOLODIR}backend.c 
-	${CC} ${CFLAGS} -c ${BOLODIR}backend.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}backend.c
 
 util.o: ${BOLODIR}util.c ${BOLODIR}util.h
-	${CC} ${CFLAGS} -c ${BOLODIR}util.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}util.c
 
 crc.o: ${BOLODIR}crc.c ${BOLODIR}crc.h
-	${CC} ${CFLAGS} -c ${BOLODIR}crc.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}crc.c
 
 shells.o: ${BOLODIR}shells.c ${BOLODIR}shells.h
-	${CC} ${CFLAGS} -c ${BOLODIR}shells.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}shells.c
 
 screenbullet.o: ${BOLODIR}screenbullet.c ${BOLODIR}screenbullet.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenbullet.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenbullet.c
 
 playersrejoin.o: ${BOLODIR}playersrejoin.c ${BOLODIR}playersrejoin.h
-	${CC} ${CFLAGS} -c ${BOLODIR}playersrejoin.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}playersrejoin.c
 
 bases.o: ${BOLODIR}bases.h ${BOLODIR}bases.c
-	${CC} ${CFLAGS} -c ${BOLODIR}bases.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}bases.c
 bolo_map.o: ${BOLODIR}bolo_map.c ${BOLODIR}bolo_map.h
-	${CC} ${CFLAGS} -c ${BOLODIR}bolo_map.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}bolo_map.c
 building.o: ${BOLODIR}building.c ${BOLODIR}building.h
-	${CC} ${CFLAGS} -c ${BOLODIR}building.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}building.c
 explosions.o: ${BOLODIR}explosions.c ${BOLODIR}explosions.h
-	${CC} ${CFLAGS} -c ${BOLODIR}explosions.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}explosions.c
 floodfill.o: ${BOLODIR}floodfill.c ${BOLODIR}floodfill.h
-	${CC} ${CFLAGS} -c ${BOLODIR}floodfill.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}floodfill.c
 gametype.o: ${BOLODIR}gametype.c ${BOLODIR}gametype.h
-	${CC} ${CFLAGS} -c ${BOLODIR}gametype.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}gametype.c
 grass.o: ${BOLODIR}grass.c ${BOLODIR}grass.h
-	${CC} ${CFLAGS} -c ${BOLODIR}grass.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}grass.c
 labels.o: ${BOLODIR}labels.c ${BOLODIR}labels.h
-	${CC} ${CFLAGS} -c ${BOLODIR}labels.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}labels.c
 lgm.o: ${BOLODIR}lgm.c ${BOLODIR}lgm.h
-	${CC} ${CFLAGS} -c ${BOLODIR}lgm.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}lgm.c
 log.o: ${BOLODIR}log.c ${BOLODIR}log.h
-	${CC} ${CFLAGS} -c ${BOLODIR}log.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}log.c
 mathWinbolo.o: ${BOLODIR}mathWinbolo.c ${BOLODIR}mathWinbolo.h
-	${CC} ${CFLAGS} -c ${BOLODIR}mathWinbolo.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}mathWinbolo.c
 
 messages.o: ${BOLODIR}messages.c ${BOLODIR}messages.h
-	${CC} ${CFLAGS} -c ${BOLODIR}messages.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}messages.c
 
 mines.o: ${BOLODIR}mines.c ${BOLODIR}mines.h
-	${CC} ${CFLAGS} -c ${BOLODIR}mines.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}mines.c
 minesexp.o: ${BOLODIR}minesexp.c ${BOLODIR}minesexp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}minesexp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}minesexp.c
 netmt.o: ${BOLODIR}netmt.c ${BOLODIR}netmt.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netmt.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netmt.c
 
 netplayers.o: ${BOLODIR}netplayers.c ${BOLODIR}netplayers.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netplayers.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netplayers.c
 
 netpnb.o: ${BOLODIR}netpnb.c ${BOLODIR}netpnb.h
-	${CC} ${CFLAGS} -c ${BOLODIR}netpnb.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}netpnb.c
 
 network.o: ${BOLODIR}network.c ${BOLODIR}network.h ${SERVERDIR}rsaalgorithm.h
-	${CC} ${CFLAGS} -c ${BOLODIR}network.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}network.c
 pillbox.o: ${BOLODIR}pillbox.c ${BOLODIR}pillbox.h
-	${CC} ${CFLAGS} -c ${BOLODIR}pillbox.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}pillbox.c
 players.o: ${BOLODIR}players.c ${BOLODIR}players.h
-	${CC} ${CFLAGS} -c ${BOLODIR}players.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}players.c
 
 rubble.o: ${BOLODIR}rubble.c ${BOLODIR}rubble.h
-	${CC} ${CFLAGS} -c ${BOLODIR}rubble.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}rubble.c
 
 screenbrainmap.o: ${BOLODIR}screenbrainmap.c ${BOLODIR}screenbrainmap.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenbrainmap.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenbrainmap.c
 
 screencalc.o: ${BOLODIR}screencalc.c ${BOLODIR}screencalc.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screencalc.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screencalc.c
 
 screenlgm.o: ${BOLODIR}screenlgm.c ${BOLODIR}screenlgm.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screenlgm.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screenlgm.c
 screentank.o: ${BOLODIR}screentank.c ${BOLODIR}screentank.h
-	${CC} ${CFLAGS} -c ${BOLODIR}screentank.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}screentank.c
 scroll.o: ${BOLODIR}scroll.c ${BOLODIR}scroll.h
-	${CC} ${CFLAGS} -c ${BOLODIR}scroll.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}scroll.c
 
 sounddist.o: ${BOLODIR}sounddist.c ${BOLODIR}sounddist.h
-	${CC} ${CFLAGS} -c ${BOLODIR}sounddist.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}sounddist.c
 starts.o: ${BOLODIR}starts.c ${BOLODIR}starts.h
-	${CC} ${CFLAGS} -c ${BOLODIR}starts.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}starts.c
 swamp.o: ${BOLODIR}swamp.c ${BOLODIR}swamp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}swamp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}swamp.c
 tank.o: ${BOLODIR}tank.c ${BOLODIR}tank.h
-	${CC} ${CFLAGS} -c ${BOLODIR}tank.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}tank.c
 allience.o: ${BOLODIR}allience.c ${BOLODIR}allience.h
-	${CC} ${CFLAGS} -c ${BOLODIR}allience.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}allience.c
 tankexp.o: ${BOLODIR}tankexp.c ${BOLODIR}tankexp.h
-	${CC} ${CFLAGS} -c ${BOLODIR}tankexp.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}tankexp.c
 treegrow.o: ${BOLODIR}treegrow.c ${BOLODIR}treegrow.h
-	${CC} ${CFLAGS} -c ${BOLODIR}treegrow.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}treegrow.c
 udppackets.o: ${BOLODIR}udppackets.c ${BOLODIR}udppackets.h
-	${CC} ${CFLAGS} -c ${BOLODIR}udppackets.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}udppackets.c
 debug_file_output.o: ${BOLODIR}debug_file_output.c ${BOLODIR}debug_file_output.h
-	${CC} ${CFLAGS} -c ${BOLODIR}debug_file_output.c
+	${CC} ${BOLO_CFLAGS} -c ${BOLODIR}debug_file_output.c
 
 #
 # LZW
@@ -283,21 +284,21 @@ ecodlzw.o: ${COMPRESSDIR}ecodlzw.c
 
 # Server 
 servercore.o: ${SERVERDIR}servercore.c ${SERVERDIR}servercore.h
-	${CC} ${CFLAGS} -c ${SERVERDIR}servercore.c
+	${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}servercore.c
 
 servermessages.o: ${SERVERDIR}servermessages.c ${BOLODIR}messages.h
-	 ${CC} ${CFLAGS} -c ${SERVERDIR}servermessages.c
+	 ${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}servermessages.c
 
 serverfrontend.o: ${SERVERDIR}serverfrontend.c 
-	${CC} ${CFLAGS} -c ${SERVERDIR}serverfrontend.c
+	${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}serverfrontend.c
 
 servermain.o: ${SERVERDIR}servermain.c
-	${CC} ${CFLAGS} -c ${SERVERDIR}servermain.c
+	${CC} ${BOLO_CFLAGS} -c ${SERVERDIR}servermain.c
 servernet.o: ${SERVERDIR}servernet.c ${SERVERDIR}servernet.h ${SERVERDIR}rsaalgorithm.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}servernet.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}servernet.c
 servertransport.o: ${SERVERDIR}servertransport.c ${SERVERDIR}servertransport.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}servertransport.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}servertransport.c
 
 threads.o: ${SERVERDIR}threads.c ${SERVERDIR}threads.h
-	${CC}  ${CFLAGS} -c ${SERVERDIR}threads.c
+	${CC}  ${BOLO_CFLAGS} -c ${SERVERDIR}threads.c
 

--- a/winbolo/src/server/servercore.c
+++ b/winbolo/src/server/servercore.c
@@ -107,6 +107,7 @@ time_t sTimeStart;
 bool serverCoreGameRunning = FALSE;
 
 void serverMessagesSetLogFile(char *logFile);
+void tankResetHitCount(tank *value);
 
 /*********************************************************
 *NAME:          serverCoreCreate

--- a/winbolo/src/server/servermain.c
+++ b/winbolo/src/server/servermain.c
@@ -53,6 +53,8 @@
 #include <ctype.h>
 #include <time.h>
 
+bool httpSendLogFile(char *fileName, BYTE *key, bool wantFeedback);
+
 DWORD oldTick;     /* Number of ticks passed */
 bool quitOnWinFlag = FALSE;
 bool autoClose = FALSE;
@@ -221,7 +223,6 @@ void processKeys() {
 
 	char playerKick[33] = "\0";
 
-	int i=0;
 	size_t newbuflen;
 
   timer.tv_sec = 1;
@@ -340,7 +341,6 @@ void CALLBACK serverGameTimer(UINT uID, UINT uMsg, DWORD dwUser, DWORD dw1, DWOR
       oldTick += SERVER_TICK_LENGTH;
     }
     if (quitOnWinFlag == TRUE || autoClose == TRUE || (winbolonetIsRunning() == TRUE && serverCoreGetActualGameType() != gameOpen)) {
-		BYTE key[64];
       threadsWaitForMutex();
       if (quitOnWinFlag == TRUE && isGameOver == FALSE){
 		isGameOver = serverCoreCheckGameWin(printGameWinners);
@@ -674,7 +674,7 @@ int main(int argc, char **argv) {
 
   /* Debugging file stuff */
   setWriteToDebugFileStream(-1);
-  setFileName(&debugFileName);
+  setFileName(debugFileName);
   if (openDebugFile() == -1) {
 	setWriteToDebugFileStream(-1);
   }

--- a/winbolo/src/server/servertransport.c
+++ b/winbolo/src/server/servertransport.c
@@ -25,6 +25,7 @@
 *  WinBolo Server Transport layer.
 *********************************************************/
 
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 #ifdef _WIN32
@@ -98,7 +99,6 @@ bool serverTransportCreate(unsigned short port, char *addrToUse) {
   bool returnValue = TRUE; /* Value to return */
   int ret;                 /* Function returns */
   struct sockaddr_in addr; /* Socket structure */
-  u_long noBlock;            /* Used to set blocking state */
   unsigned long ad;        /* Address */
 
   screenServerConsoleMessage((char *) "Server Transport Startup");
@@ -137,7 +137,6 @@ bool serverTransportCreate(unsigned short port, char *addrToUse) {
 
   /* Set to non blocking */
   if (returnValue == TRUE) {
-    noBlock = NO_BLOCK_SOCK;
     ret = fcntl(sockUdp, F_SETFL, O_NONBLOCK | fcntl(sockUdp, F_GETFL));
     if (ret == SOCKET_ERROR) {
       returnValue = FALSE;
@@ -185,7 +184,7 @@ void serverTransportListenUDP(void) {
   BYTE info[512 /*MAX_PACKET_SIZE */];  /* The packet                 */
   int packetLen;               /* Size of the packet         */
   struct sockaddr_in from;     /* Where the packet came from */
-  int fromlen;                 /* size of the from struct    */
+  unsigned int fromlen;                 /* size of the from struct    */
   
   fromlen = sizeof(from);
   packetLen = recvfrom(sockUdp, info, 512 /* MAX_PACKET_SIZE*/ , 0, (struct sockaddr *)&from, &fromlen);
@@ -268,7 +267,6 @@ void serverTransportGetUs(struct in_addr *dest, unsigned short *port) {
 *********************************************************/
 void serverTransportSendUDPLast(BYTE *buff, int len, bool wantCrc) {
   BYTE crcA, crcB;
-  int i;
 
   if (wantCrc == TRUE) {
     CRCCalcBytes(buff, len, &crcA, &crcB);
@@ -276,7 +274,7 @@ void serverTransportSendUDPLast(BYTE *buff, int len, bool wantCrc) {
     buff[len+1] = crcB;
     len+=2;
   }
-  i = sendto(sockUdp, (char *) buff, len, 0, (struct sockaddr *)&addrLast, sizeof(addrLast));
+  sendto(sockUdp, (char *) buff, len, 0, (struct sockaddr *)&addrLast, sizeof(addrLast));
 }
 
 // FIXME: Prototype

--- a/winbolo/src/winbolonet/http.c
+++ b/winbolo/src/winbolonet/http.c
@@ -25,6 +25,8 @@
 *  Responsable for sending/receiving http messages
 *********************************************************/
 
+#include <ctype.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -208,7 +210,6 @@ int httpDecodeData(BYTE *buff, int len) {
 * maxLen - Maximum length of the byte buffer
 *********************************************************/
 int httpEncodeData(BYTE *src, int len, BYTE *dest, int maxLen) {
-  int returnValue; /* Value to return */
   int count;
   int encodeCount;
   char temp[3];
@@ -241,7 +242,7 @@ int httpEncodeData(BYTE *src, int len, BYTE *dest, int maxLen) {
   }
 
   if (encodeCount > maxLen) {
-    returnValue = -1;
+    //returnValue = -1;
   }
   return encodeCount;
 }
@@ -420,13 +421,12 @@ int httpSendMessage(BYTE *message, int len, BYTE *response, int maxSize) {
 long httpGetFileLength(char *fileName) {
   long returnValue = -1; /* Value to return */
   FILE *fp;
-  char temp;
 
   fp = fopen(fileName, "rb");
   if (fp) {
     returnValue = 0;
     while (!feof(fp)) {
-      temp = fgetc(fp);
+      fgetc(fp);
       returnValue++;
     }
     fclose(fp);

--- a/winbolo/src/winbolonet/winbolonetthread.c
+++ b/winbolo/src/winbolonet/winbolonetthread.c
@@ -35,6 +35,7 @@
 	typedef SDL_mutex *HANDLE;
   	typedef int DWORD; /* Not used by required by windows code */
 #endif
+#include <unistd.h>
 #include <string.h>
 #include "../bolo/global.h"
 #include "http.h"
@@ -66,7 +67,6 @@ bool wbnFinished;
 *********************************************************/
 bool winbolonetThreadCreate(void) {
   bool returnValue;        /* Value to return */
-  char name[FILENAME_MAX]; /* Used in Mutex creation */
 
   returnValue = TRUE;
   wbnProcessing = NULL;
@@ -75,6 +75,7 @@ bool winbolonetThreadCreate(void) {
   wbnFinished = FALSE;
   
 #ifdef _WIN32
+  char name[FILENAME_MAX]; /* Used in Mutex creation */
   sprintf(name, "%s%d", "WBNUPDATE", GetTickCount());
   hWbnMutexHandle = CreateMutex(NULL, FALSE, (LPCTSTR ) name);
 #else
@@ -121,7 +122,6 @@ bool winbolonetThreadCreate(void) {
 *********************************************************/
 void winbolonetThreadDestroy(void) {
   wbnList del;   /* Use to delete our queues */
-  DWORD val = 0; /* Thread Exit Value for WIN32 */
 
   if (hWbnMutexHandle != NULL) { /* FIXME: Will be non null if we started it OK. Is there a better way? (threadid?) */
     /* Wait for all events to be sent... */
@@ -146,6 +146,7 @@ void winbolonetThreadDestroy(void) {
 
     /* End Thread */
 #ifdef _WIN32
+    DWORD val = 0; /* Thread Exit Value for WIN32 */
     WaitForSingleObject(hWbnThread, WBN_WAIT_THREAD_EXIT);
     GetExitCodeThread(hWbnThread, &val);
     if (val == STILL_ACTIVE) {
@@ -256,7 +257,7 @@ int winbolonetThreadRun() {
       /* Get last entry */
       if (wbnProcessing->next == NULL) {
         /* Only one entry */
-        httpSendMessage(wbnProcessing->data, wbnProcessing->len, dest, 512);
+        httpSendMessage(wbnProcessing->data, wbnProcessing->len, (BYTE *) dest, 512);
         Dispose(wbnProcessing);
 	wbnProcessing = NULL; 
       } else {
@@ -268,7 +269,7 @@ int winbolonetThreadRun() {
         }
         /* Got last entry */
         prev->next = NULL;
-        httpSendMessage(q->data, q->len, dest, 512);
+        httpSendMessage(q->data, q->len, (BYTE *) dest, 512);
         Dispose(q);
       }
     }


### PR DESCRIPTION
Add `-Wall` and compile cleanly on Ubuntu trusty with gcc 4.8.1.

This also fixes a few bugs (mostly the wrong size being fed to various networking APIs, etc).

In some places, we cheat by adding forward declarations inside of the relevant `.c` file, rather than including the header.  The header likely has windows-specific bits we can't directly include (yet).